### PR TITLE
Script changes to support Zephyr SDK 0.9

### DIFF
--- a/install-zephyr.sh
+++ b/install-zephyr.sh
@@ -5,6 +5,11 @@ Z_PATH=$(readlink -m "$(pwd)/../zephyr")
 ZSDK_FILE="zephyr-sdk-${ZSDK_VER}-i686-setup.run"
 ZSDK_PATH=$(readlink -m "$(pwd)/../zephyr-sdk")
 
+cleanup() {
+	rm -f /tmp/${ZSDK_FILE}
+}
+trap cleanup EXIT
+
 if [ -d ${Z_PATH} ]; then
     echo "Zephyr source already exists. Skipping installation."
 else

--- a/install-zephyr.sh
+++ b/install-zephyr.sh
@@ -19,7 +19,10 @@ if [ -d "${ZSDK_PATH}" ]; then
 else
     if [ ! -f /tmp/${ZSDK_FILE} ] ; then
         echo "Downloading Zephyr SDK"
-        curl -o /tmp/${ZSDK_FILE} -L https://nexus.zephyrproject.org/content/repositories/releases/org/zephyrproject/zephyr-sdk/${ZSDK_VER}-i686/${ZSDK_FILE}
+        if ! curl --fail -o /tmp/${ZSDK_FILE} -L https://nexus.zephyrproject.org/content/repositories/releases/org/zephyrproject/zephyr-sdk/${ZSDK_VER}-i686/${ZSDK_FILE}; then
+		ZSDK_FILE="zephyr-sdk-${ZSDK_VER}-setup.run"
+		curl --fail -o /tmp/${ZSDK_FILE} -L https://nexus.zephyrproject.org/content/repositories/releases/org/zephyrproject/zephyr-sdk/${ZSDK_VER}/${ZSDK_FILE}
+	fi
         chmod 755 /tmp/${ZSDK_FILE}
     fi
     echo "Installing Zephyr SDK to ${ZSDK_PATH}"


### PR DESCRIPTION
Hi, I noticed the path to the Zephyr SDK 0.9 changed convention https://nexus.zephyrproject.org/content/repositories/releases/org/zephyrproject/zephyr-sdk/0.9/ . Specifically, the "-i686" was dropped. Here's a simple update to the `install-zephyr.sh` script to support it.

I also added a trap to cleanup the temp file created in the process. This is important since `curl` will create the file on error (it will contain a 404 page most likely).

Thanks for putting together the CODK-Z repo. Makes getting started with Curie so much easier!